### PR TITLE
Bug fix: Buffer sizes in dibf-bf-results.txt no longer produce size zero when size values are equivalent.

### DIFF
--- a/dibf/FuzzingProvider.cpp
+++ b/dibf/FuzzingProvider.cpp
@@ -45,6 +45,10 @@ BOOL Dumbfuzzer::GetRandomIoctlAndBuffer(DWORD &iocode, vector<UCHAR> &output, m
     if(ioStore[ioctlIndex].dwUpperSize-ioStore[ioctlIndex].dwLowerSize) {
         size = ioStore[ioctlIndex].dwLowerSize+(HIGH_WORD(r)%(ioStore[ioctlIndex].dwUpperSize-ioStore[ioctlIndex].dwLowerSize));
     }
+    // If the sizes are equal, take the upper size
+    else if(ioStore[ioctlIndex].dwUpperSize == ioStore[ioctlIndex].dwLowerSize){
+        size = ioStore[ioctlIndex].dwUpperSize;
+    }
     output.resize(size);
     if(size>4) {
         for(i=0; i<(INT)(size-sizeof(INT)); i+=sizeof(INT)) {

--- a/dibf/FuzzingProvider.cpp
+++ b/dibf/FuzzingProvider.cpp
@@ -46,7 +46,7 @@ BOOL Dumbfuzzer::GetRandomIoctlAndBuffer(DWORD &iocode, vector<UCHAR> &output, m
         size = ioStore[ioctlIndex].dwLowerSize+(HIGH_WORD(r)%(ioStore[ioctlIndex].dwUpperSize-ioStore[ioctlIndex].dwLowerSize));
     }
     // If the sizes are equal, take the upper size
-    else if(ioStore[ioctlIndex].dwUpperSize == ioStore[ioctlIndex].dwLowerSize){
+    else if(ioStore[ioctlIndex].dwUpperSize == ioStore[ioctlIndex].dwLowerSize) {
         size = ioStore[ioctlIndex].dwUpperSize;
     }
     output.resize(size);


### PR DESCRIPTION
When ioStore[ioctlIndex].dwUpperSize was equal to ioStore[ioctlIndex].dwLowerSize, the result was a size of zero. This patch produces the upper size when they are equal instead of producing zero. 

// If the sizes are equal, take the upper size
    else if(ioStore[ioctlIndex].dwUpperSize == ioStore[ioctlIndex].dwLowerSize) {
        size = ioStore[ioctlIndex].dwUpperSize;
    }
